### PR TITLE
Allow extending OidcClient with new functionality by making key dependencies protected

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+## Tombola.IdentityModel.OidcClient, a fork of IdentityModel.OidcClient
+This fork exists so that we can use `IdentityModel.OidcClient` in .NET Framework, but add additional features when we consume it.
+Some of the types inside the package were too restrictive for us to be able to do this.
+
+### Branches
+Due to this being a fork of a public repository, the `main` branch is left as it is upstream, with the upstream set to `IdentityModel.OidcClient:main`.
+Releases are made from the repository's default branch, `tombola-release`, and pull requests should target this branch.
+`main` should only be used to pull new versions from the upstream; changes from `main` should then be brought to `tombola-release` via a pull request.
+
 # C#/NetStandard OpenID Connect Client Library for native Applications
 Supported platforms: netstandard14, desktop .NET, UWP, .NET Core, Xamarin iOS & Android. [Nuget.](https://www.nuget.org/packages/IdentityModel.OidcClient/)
 

--- a/src/OidcClient/Infrastructure/OidcClientOptionsExtensions.cs
+++ b/src/OidcClient/Infrastructure/OidcClientOptionsExtensions.cs
@@ -6,9 +6,17 @@ using System.Net.Http;
 
 namespace IdentityModel.OidcClient.Infrastructure
 {
-    internal static class OidcClientOptionsExtensions
+    /// <summary>
+    /// Extension methods over <see cref="OidcClientOptions"/>
+    /// </summary>
+    public static class OidcClientOptionsExtensions
     {
-        public static HttpClient CreateClient(this OidcClientOptions options)
+        /// <summary>
+        /// Creates an <see cref="HttpClient"/> configured for backchannel requests to the authorization server
+        /// </summary>
+        /// <param name="options">Client options</param>
+        /// <returns>A new <see cref="HttpClient"/></returns>
+        public static HttpClient CreateBackchannelClient(this OidcClientOptions options)
         {
             if (options.HttpClientFactory != null)
             {

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -42,6 +42,17 @@ namespace IdentityModel.OidcClient
         /// <param name="options">The options.</param>
         /// <exception cref="System.ArgumentNullException">options</exception>
         public OidcClient(OidcClientOptions options)
+            : this(options, (clientOptions, EnsureProviderInformationAsync) => new ResponseProcessor(clientOptions, EnsureProviderInformationAsync))
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="OidcClient"/> class.
+        /// </summary>
+        /// <param name="options">The options.</param>
+        /// <param name="responseProcessorFactory">Factory function to use a custom override of <see cref="ResponseProcessor"/></param>
+        /// <exception cref="System.ArgumentNullException">options</exception>
+        public OidcClient(OidcClientOptions options, Func<OidcClientOptions, Func<CancellationToken, Task>, ResponseProcessor> responseProcessorFactory)
         {
             if (options == null) throw new ArgumentNullException(nameof(options));
 
@@ -54,7 +65,7 @@ namespace IdentityModel.OidcClient
             Options = options;
             _logger = options.LoggerFactory.CreateLogger<OidcClient>();
             _authorizeClient = new AuthorizeClient(options);
-            _processor = new ResponseProcessor(options, EnsureProviderInformationAsync);
+            _processor = responseProcessorFactory(options, EnsureProviderInformationAsync);
         }
 
         /// <summary>
@@ -366,7 +377,7 @@ namespace IdentityModel.OidcClient
             };
         }
 
-        protected async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
+        protected internal async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
         {
             await EnsureProviderInformationAsync(cancellationToken);
 
@@ -374,7 +385,7 @@ namespace IdentityModel.OidcClient
             _logger.LogTrace(LogSerializer.Serialize(Options));
         }
 
-        protected async Task EnsureProviderInformationAsync(CancellationToken cancellationToken)
+        protected internal async Task EnsureProviderInformationAsync(CancellationToken cancellationToken)
         {
             _logger.LogTrace("EnsureProviderInformation");
 

--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -22,11 +22,11 @@ namespace IdentityModel.OidcClient
     /// </summary>
     public class OidcClient
     {
-        private readonly ILogger _logger;
+        protected readonly ILogger _logger;
         private readonly AuthorizeClient _authorizeClient;
 
         private readonly bool _useDiscovery;
-        private readonly ResponseProcessor _processor;
+        protected readonly ResponseProcessor _processor;
 
         /// <summary>
         /// Gets the options.
@@ -285,7 +285,7 @@ namespace IdentityModel.OidcClient
             if (accessToken.IsMissing()) throw new ArgumentNullException(nameof(accessToken));
             if (!Options.ProviderInformation.SupportsUserInfo) throw new InvalidOperationException("No userinfo endpoint specified");
 
-            var userInfoClient = Options.CreateClient();
+            var userInfoClient = Options.CreateBackchannelClient();
 
             var userInfoResponse = await userInfoClient.GetUserInfoAsync(new UserInfoRequest
             {
@@ -326,7 +326,7 @@ namespace IdentityModel.OidcClient
             await EnsureConfigurationAsync(cancellationToken);
             backChannelParameters = backChannelParameters ?? new Parameters();
             
-            var client = Options.CreateClient();
+            var client = Options.CreateBackchannelClient();
 
             var response = await client.RequestRefreshTokenAsync(new RefreshTokenRequest
             {
@@ -366,7 +366,7 @@ namespace IdentityModel.OidcClient
             };
         }
 
-        internal async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
+        protected async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
         {
             await EnsureProviderInformationAsync(cancellationToken);
 
@@ -374,7 +374,7 @@ namespace IdentityModel.OidcClient
             _logger.LogTrace(LogSerializer.Serialize(Options));
         }
 
-        internal async Task EnsureProviderInformationAsync(CancellationToken cancellationToken)
+        protected async Task EnsureProviderInformationAsync(CancellationToken cancellationToken)
         {
             _logger.LogTrace("EnsureProviderInformation");
 
@@ -391,7 +391,7 @@ namespace IdentityModel.OidcClient
                     }
                 }
 
-                var discoveryClient = Options.CreateClient();
+                var discoveryClient = Options.CreateBackchannelClient();
                 var disco = await discoveryClient.GetDiscoveryDocumentAsync(new DiscoveryDocumentRequest
                 {
                     Address = Options.Authority,

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -20,8 +20,8 @@ namespace IdentityModel.OidcClient
     /// </summary>
     public class ResponseProcessor
     {
-        private readonly OidcClientOptions _options;
-        private readonly ILogger<ResponseProcessor> _logger;
+        protected readonly OidcClientOptions _options;
+        protected readonly ILogger<ResponseProcessor> _logger;
         private readonly CryptoHelper _crypto;
         private readonly Func<CancellationToken, Task> _refreshKeysAsync;
 
@@ -102,7 +102,7 @@ namespace IdentityModel.OidcClient
             };
         }
 
-        public async Task<TokenResponseValidationResult> ValidateTokenResponseAsync(TokenResponse response, AuthorizeState state, bool requireIdentityToken, CancellationToken cancellationToken = default)
+        public virtual async Task<TokenResponseValidationResult> ValidateTokenResponseAsync(TokenResponse response, AuthorizeState state, bool requireIdentityToken, CancellationToken cancellationToken = default)
         {
             _logger.LogTrace("ValidateTokenResponse");
 

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -15,7 +15,10 @@ using System.Threading.Tasks;
 
 namespace IdentityModel.OidcClient
 {
-    internal class ResponseProcessor
+    /// <summary>
+    /// Encapsulates processing of OIDC responses
+    /// </summary>
+    public class ResponseProcessor
     {
         private readonly OidcClientOptions _options;
         private readonly ILogger<ResponseProcessor> _logger;
@@ -99,7 +102,7 @@ namespace IdentityModel.OidcClient
             };
         }
 
-        internal async Task<TokenResponseValidationResult> ValidateTokenResponseAsync(TokenResponse response, AuthorizeState state, bool requireIdentityToken, CancellationToken cancellationToken = default)
+        public async Task<TokenResponseValidationResult> ValidateTokenResponseAsync(TokenResponse response, AuthorizeState state, bool requireIdentityToken, CancellationToken cancellationToken = default)
         {
             _logger.LogTrace("ValidateTokenResponse");
 
@@ -180,7 +183,7 @@ namespace IdentityModel.OidcClient
         {
             _logger.LogTrace("RedeemCodeAsync");
 
-            var client = _options.CreateClient();
+            var client = _options.CreateBackchannelClient();
             var tokenResult = await client.RequestAuthorizationCodeTokenAsync(new AuthorizationCodeTokenRequest
             {
                 Address = _options.ProviderInformation.TokenEndpoint,

--- a/src/OidcClient/Results/ResponseValidationResult.cs
+++ b/src/OidcClient/Results/ResponseValidationResult.cs
@@ -7,20 +7,41 @@ using System.Security.Claims;
 
 namespace IdentityModel.OidcClient
 {
-    internal class ResponseValidationResult : Result
+    /// <summary>
+    /// Response type returned by <see cref="ResponseProcessor"/> from validating an authorize response.
+    /// </summary>
+    public class ResponseValidationResult : Result
     {
+        /// <summary>
+        /// Default constructor
+        /// </summary>
         public ResponseValidationResult()
         {
 
         }
 
+        /// <summary>
+        /// Error constructor
+        /// </summary>
+        /// <param name="error"></param>
         public ResponseValidationResult(string error)
         {
             Error = error;
         }
 
+        /// <summary>
+        /// The original authorize response which was validated
+        /// </summary>
         public virtual AuthorizeResponse AuthorizeResponse { get; set; }
+
+        /// <summary>
+        /// The response obtained when exchanging the authorization code for tokens
+        /// </summary>
         public virtual TokenResponse TokenResponse { get; set; }
+
+        /// <summary>
+        /// A <see cref="ClaimsPrincipal"/> derived from the token response
+        /// </summary>
         public virtual ClaimsPrincipal User { get; set; }
     }
 }

--- a/src/OidcClient/Results/TokenResponseValidationResult.cs
+++ b/src/OidcClient/Results/TokenResponseValidationResult.cs
@@ -4,18 +4,32 @@
 
 namespace IdentityModel.OidcClient.Results
 {
-    internal class TokenResponseValidationResult : Result
+    /// <summary>
+    /// Response type returned by <see cref="ResponseProcessor"/> from validating a token response.
+    /// </summary>
+    public class TokenResponseValidationResult : Result
     {
+        /// <summary>
+        /// Error constructor
+        /// </summary>
+        /// <param name="error"></param>
         public TokenResponseValidationResult(string error)
         {
             Error = error;
         }
 
+        /// <summary>
+        /// Default constructor, providing a valid inner result
+        /// </summary>
+        /// <param name="result"></param>
         public TokenResponseValidationResult(IdentityTokenValidationResult result)
         {
             IdentityTokenValidationResult = result;
         }
 
+        /// <summary>
+        /// The inner result from validating the ID token
+        /// </summary>
         public virtual IdentityTokenValidationResult IdentityTokenValidationResult { get; set; }
     }
 }

--- a/test/JwtValidationTests/JwtValidationTests.csproj
+++ b/test/JwtValidationTests/JwtValidationTests.csproj
@@ -25,6 +25,10 @@
     </ItemGroup>
 
     <ItemGroup>
+        <PackageReference Include="coverlet.collector" Version="6.0.0">
+          <PrivateAssets>all</PrivateAssets>
+          <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+        </PackageReference>
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
         <PackageReference Include="xunit" Version="2.4.1" />

--- a/test/JwtValidationTests/JwtValidationTests.csproj
+++ b/test/JwtValidationTests/JwtValidationTests.csproj
@@ -2,7 +2,7 @@
 
     <!--Conditional compilation-->
     <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-        <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+        <TargetFrameworks>net472;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(NETCoreSdkPortableRuntimeIdentifier)' != 'osx-arm64' ">

--- a/test/OidcClient.Tests/OidcClient.Tests.csproj
+++ b/test/OidcClient.Tests/OidcClient.Tests.csproj
@@ -2,7 +2,7 @@
 
   <!--Conditional compilation-->
   <PropertyGroup Condition=" '$(OS)' == 'Windows_NT' ">
-    <TargetFrameworks>net472;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net6.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(OS)' != 'Windows_NT' and '$(NETCoreSdkPortableRuntimeIdentifier)' != 'osx-arm64' ">

--- a/test/OidcClient.Tests/OidcClient.Tests.csproj
+++ b/test/OidcClient.Tests/OidcClient.Tests.csproj
@@ -25,6 +25,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />

--- a/test/OidcClient.Tests/OidcClient.Tests.csproj
+++ b/test/OidcClient.Tests/OidcClient.Tests.csproj
@@ -29,7 +29,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.12.0" />
+    <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="6.15.0" />
     
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />


### PR DESCRIPTION
https://tombola.atlassian.net/browse/PE-584

Make a few key methods within `OidcClient` `protected`, rather than `private` / `internal`.
This allows us to override them in a derived class so as to customise behaviour.

In a similar vein, `ResponseProcessor.ValidateTokenResponseAsync` is made public so that it can be called from a derived class.