### PR TITLE
Keep main error message separate from error description

### DIFF
--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -4,7 +4,7 @@
     <PackageId>Tombola.IdentityModel.OidcClient</PackageId>
     <RootNamespace>Tombola.IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>Tombola.IdentityModel.OidcClient</AssemblyName>
-    <PackageVersion>5.1.2</PackageVersion>
+    <PackageVersion>5.1.3</PackageVersion>
     
     <TargetFramework>netstandard2.0</TargetFramework>
     

--- a/src/OidcClient/ResponseProcessor.cs
+++ b/src/OidcClient/ResponseProcessor.cs
@@ -80,11 +80,11 @@ namespace IdentityModel.OidcClient
             var tokenResponse = await RedeemCodeAsync(authorizeResponse.Code, state, backChannelParameters, cancellationToken);
             if (tokenResponse.IsError)
             {
-                return new ResponseValidationResult($"Error redeeming code: {tokenResponse.Error ?? "no error code"} / {tokenResponse.ErrorDescription ?? "no description"}");
+                return new ResponseValidationResult(tokenResponse.Error, $"Error redeeming code: {tokenResponse.ErrorDescription}");
             }
             if (tokenResponse.HttpStatusCode != HttpStatusCode.OK)
             {
-                return new ResponseValidationResult($"Error redeeming code: {tokenResponse.Raw}");
+                return new ResponseValidationResult(tokenResponse.Error, $"Error redeeming code: {tokenResponse.Raw}");
             }
 
             // validate token response

--- a/src/OidcClient/Results/ResponseValidationResult.cs
+++ b/src/OidcClient/Results/ResponseValidationResult.cs
@@ -24,9 +24,11 @@ namespace IdentityModel.OidcClient
         /// Error constructor
         /// </summary>
         /// <param name="error"></param>
-        public ResponseValidationResult(string error)
+        /// <param name="errorDescription"></param>
+        public ResponseValidationResult(string error, string errorDescription = null)
         {
             Error = error;
+            ErrorDescription = errorDescription;
         }
 
         /// <summary>

--- a/test/JwtValidationTests/CodeFlowResponseTestsWithJwtValidation.cs
+++ b/test/JwtValidationTests/CodeFlowResponseTestsWithJwtValidation.cs
@@ -370,7 +370,7 @@ namespace IdentityModel.OidcClient.Tests
             var result = await client.ProcessResponseAsync(url, state);
 
             result.IsError.Should().BeTrue();
-            result.Error.Should().StartWith("Error redeeming code: error");
+            result.Error.Should().Be("error");
         }
 
         [Fact]

--- a/test/OidcClient.Tests/CodeFlowResponseTests.cs
+++ b/test/OidcClient.Tests/CodeFlowResponseTests.cs
@@ -351,7 +351,7 @@ namespace IdentityModel.OidcClient.Tests
             var result = await client.ProcessResponseAsync(url, state);
 
             result.IsError.Should().BeTrue();
-            result.Error.Should().StartWith("Error redeeming code: error");
+            result.Error.Should().Be("error");
         }
 
         [Fact]


### PR DESCRIPTION
Updating the constructor for `ResponseValidationResult` to keep the main error message and error description separated, instead of concatenating them into one string on the main error message field. 

We are doing this to enable a flow later down the line in PlayerServicesAuthentication which matches on a strict list of defined error messages.