### PR TITLE
Ce 197 get authentication context from identity server

### DIFF
--- a/src/OidcClient/OidcClient.cs
+++ b/src/OidcClient/OidcClient.cs
@@ -334,7 +334,7 @@ namespace IdentityModel.OidcClient
         {
             _logger.LogTrace("RefreshTokenAsync");
 
-            await EnsureConfigurationAsync(cancellationToken);
+            await EnsureConfigurationAsync(cancellationToken).ConfigureAwait(false);
             backChannelParameters = backChannelParameters ?? new Parameters();
             
             var client = Options.CreateBackchannelClient();
@@ -379,7 +379,7 @@ namespace IdentityModel.OidcClient
 
         protected internal async Task EnsureConfigurationAsync(CancellationToken cancellationToken)
         {
-            await EnsureProviderInformationAsync(cancellationToken);
+            await EnsureProviderInformationAsync(cancellationToken).ConfigureAwait(false);
 
             _logger.LogTrace("Effective options:");
             _logger.LogTrace(LogSerializer.Serialize(Options));

--- a/src/OidcClient/OidcClient.csproj
+++ b/src/OidcClient/OidcClient.csproj
@@ -4,7 +4,7 @@
     <PackageId>Tombola.IdentityModel.OidcClient</PackageId>
     <RootNamespace>Tombola.IdentityModel.OidcClient</RootNamespace>
     <AssemblyName>Tombola.IdentityModel.OidcClient</AssemblyName>
-    <PackageVersion>5.1.2</PackageVersion>
+    <PackageVersion>5.1.4</PackageVersion>
     
     <TargetFramework>netstandard2.0</TargetFramework>
     


### PR DESCRIPTION
**Ticket link:**
https://tombola.atlassian.net/browse/CE-197
- [ ] Breaking Change

### What?
Rejig RefreshTokensAsync to use configureawait(false)

## Why? 
RefreshTokensAsync is deadlocking in framework, adding configureAwaitFalse will prevent this from long running operations.